### PR TITLE
B4 Highlighted WorldObject #69

### DIFF
--- a/src/AutomatedCar/Views/CourseDisplayView.xaml
+++ b/src/AutomatedCar/Views/CourseDisplayView.xaml
@@ -58,6 +58,12 @@
 						<Polyline IsVisible="{Binding $parent[ItemsControl].DataContext.DebugOn}" Stroke="{Binding Brush, Mode=OneWay}"
 									Points="{Binding Geometry.Points, Mode=OneWay}" />
 
+						<Polyline IsVisible="{Binding IsHighlighted, Mode=OneWay}"
+									Stroke="yellow"
+									StrokeThickness="4"
+									Opacity=".7"
+									Points="{Binding Geometry.Points, Mode=OneWay}" />
+
 						<Polyline
 							IsVisible="{Binding RadarVisible, Mode=OneWay}"
 							Opacity=".4"
@@ -88,6 +94,12 @@
 							Source="{Binding FileName, Converter={x:Static visualization:WorldObjectTransformer.Instance}}"/>
 						<Polyline Stroke="{Binding Brush, Mode=OneWay}"
 									Points="{Binding Geometry.Points, Mode=OneWay}" />
+
+						<Polyline IsVisible="{Binding IsHighlighted, Mode=OneWay}"
+									Stroke="yellow"
+									StrokeThickness="4"
+									Opacity=".6"
+									Points="{Binding Geometry.Points, Mode=OneWay}" />						
 					</Canvas>
 				</DataTemplate>
             </ItemsControl.DataTemplates>


### PR DESCRIPTION
Polyline is tricky. In the models:AutomatedCar DataType DataTemplate are work but in the models:WorldObject are not because no Geometry.Points provided for other type of models. Team B2 should fix this by adding Geometry to other models or pull up the Geometry property to WordObject