### PR TITLE
B4 refactor polygons from t2 fix polygon tranform

### DIFF
--- a/src/AutomatedCar/Views/CourseDisplayView.xaml
+++ b/src/AutomatedCar/Views/CourseDisplayView.xaml
@@ -60,7 +60,7 @@
                         </Image>
                     </Canvas>
                     <Canvas>
-                        <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons[0], Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
+                        <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons, Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
                     </Canvas>
                 </Canvas>
                 </DataTemplate>
@@ -91,29 +91,7 @@
                                     <TranslateTransform  Y="{Binding referenceOffsetY}" />
                                 </TransformGroup>
                             </Canvas.RenderTransform>
-                            <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons[0], Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
-                        </Canvas>
-                        <Canvas>
-                            <Canvas.RenderTransform>
-                                <TransformGroup>
-                                    <TranslateTransform  X="{Binding X}" />
-                                    <TranslateTransform  Y="{Binding Y}" />
-                                    <TranslateTransform  X="{Binding referenceOffsetX}" />
-                                    <TranslateTransform  Y="{Binding referenceOffsetY}" />
-                                </TransformGroup>
-                            </Canvas.RenderTransform>
-                            <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons[1], Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
-                        </Canvas>
-                        <Canvas>
-                            <Canvas.RenderTransform>
-                                <TransformGroup>
-                                    <TranslateTransform  X="{Binding X}" />
-                                    <TranslateTransform  Y="{Binding Y}" />
-                                    <TranslateTransform  X="{Binding referenceOffsetX}" />
-                                    <TranslateTransform  Y="{Binding referenceOffsetY}" />
-                                </TransformGroup>
-                            </Canvas.RenderTransform>
-                            <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons[2], Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
+                            <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons, Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
                         </Canvas>
                     </Canvas>
                 </DataTemplate>
@@ -144,7 +122,7 @@
                                     <TranslateTransform  Y="{Binding referenceOffsetY}" />
                                 </TransformGroup>
                             </Canvas.RenderTransform>
-                            <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons[0], Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
+                            <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons, Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
                         </Canvas>
                     </Canvas>
                 </DataTemplate>

--- a/src/AutomatedCar/Views/CourseDisplayView.xaml
+++ b/src/AutomatedCar/Views/CourseDisplayView.xaml
@@ -91,6 +91,18 @@
                                     <TranslateTransform  Y="{Binding referenceOffsetY}" />
                                 </TransformGroup>
                             </Canvas.RenderTransform>
+                            <!-- <ItemsControl
+                            Items="{Binding NetPolygons}"
+                            Tag="{Binding Coordinates}"
+                            >
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <Canvas>
+                                            <Polyline Stroke="Red" Points="{Binding $parent[ItemsControl].Tag, Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
+                                        </Canvas>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                            </ItemsControl> -->
                             <Polyline Stroke="{Binding Brush, Mode=OneWay}" Points="{Binding NetPolygons, Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
                         </Canvas>
                     </Canvas>

--- a/src/AutomatedCar/Visualization/CoordinateConverter.cs
+++ b/src/AutomatedCar/Visualization/CoordinateConverter.cs
@@ -13,10 +13,10 @@ namespace AutomatedCar.Visualization
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
 
-            NetTopologySuite.Geometries.LineString NTGeometry = (value as NetTopologySuite.Geometries.LineString);
+            List<NetTopologySuite.Geometries.LineString> NTGeometry = (value as List<NetTopologySuite.Geometries.LineString>);
             List<Avalonia.Point> list = new List<Avalonia.Point>();
 
-            foreach(var coordinate in NTGeometry.Coordinates)
+            foreach(var coordinate in NTGeometry[0].Coordinates)
             {
                 list.Add(new Avalonia.Point(coordinate.X, coordinate.Y));
             }

--- a/src/AutomatedCar/Visualization/CoordinateConverter.cs
+++ b/src/AutomatedCar/Visualization/CoordinateConverter.cs
@@ -12,13 +12,14 @@ namespace AutomatedCar.Visualization
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-
             List<NetTopologySuite.Geometries.LineString> NTGeometry = (value as List<NetTopologySuite.Geometries.LineString>);
             List<Avalonia.Point> list = new List<Avalonia.Point>();
 
-            foreach(var coordinate in NTGeometry[0].Coordinates)
-            {
-                list.Add(new Avalonia.Point(coordinate.X, coordinate.Y));
+            foreach(var ntg in NTGeometry) {
+                foreach(var coordinate in ntg.Coordinates)
+                {
+                    list.Add(new Avalonia.Point(coordinate.X, coordinate.Y));
+                }
             }
             
             return list.ToArray();


### PR DESCRIPTION
@pintergreg, az utak poligonjáról kiderült hogy a számuk nem meghatározott, így nem sikerült beégetéssel megoldani a kirajzolásukat. Jelenleg úgy próbáltam nem beégetni, hogy a converterben gyártottam belőle egy nagy poligont, csak ez összekötötte az egyes poligonok széleit. 
Kipróbáltam egy ilyen kódot (bent hagytam kikommentezve):
```c#
<ItemsControl
                            Items="{Binding NetPolygons}"
                            Tag="{Binding Coordinates}"
                            >
                                <ItemsControl.ItemsPanel>
                                    <ItemsPanelTemplate>
                                        <Canvas>
                                            <Polyline Stroke="Red" Points="{Binding $parent[ItemsControl].Tag, Converter={x:Static visualization:CoordinateConverter.Instance}}}"/>
                                        </Canvas>
                                    </ItemsPanelTemplate>
                                </ItemsControl.ItemsPanel>
                            </ItemsControl>
```
Az vele a baj, hogy az Items attribútum nem úgy viselkedik mint a külső ItemsControl-ban, és belül nem az egyes Netpolygon-ok lesznek a context. Ezzel a parentes tages dologgal próbáltam kikényszeríteni, de így sem működött. Emlékszem hogy korábban volt hasonló kód amit küldtél, de nem találom hol volt. 